### PR TITLE
Typos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ clear and has sufficient instructions to be able to reproduce the issue.
 ## Coding Guidelines
 * Please follow Framework Design Guidelines
 * Please follow SOLID principles
-* Make sure you have familiarized yourself with [Cuemon for .NET - Concept Reference](https://docs.cuemon.net/api/index.html)
+* Make sure you have familiarized yourself with [Cuemon for .NET - Concept Reference](https://docs.cuemon.net/)
 * Consider reading my short take on [Software craftsmanship - a journey with inspirational sources!](https://github.com/gimlichael/Must-Read-Resources)
 
 ## Manifesto

--- a/.nuget/Cuemon.Extensions.IO/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.IO/PackageReleaseNotes.txt
@@ -1,5 +1,5 @@
 ﻿Version: 8.0.0
-Availability: .NET 8, .NET 7, .NET 6 and .NET Standard 2.0
+Availability: .NET 8, .NET 7, .NET 6 .NET Standard 2.1 and .NET Standard 2.0
  
 # ALM
 - ADDED TFM for net8.0


### PR DESCRIPTION
- Fixed URL for Concept Reference @ docs.cuemon.net
- Fixed availability to include netstandard2.1
- No code changes