### PR TITLE
V9.0.0/xunit testoutputhelperaccessor

### DIFF
--- a/.nuget/Cuemon.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Xunit.Hosting/PackageReleaseNotes.txt
@@ -6,6 +6,7 @@ Availability: .NET 9, .NET 8, .NET 6 and .NET Standard 2.0
  
 # New Features
 - ADDED ServiceProviderExtensions class in the Cuemon.Extensions.Xunit.Hosting namespace that consist of one extension method for the IServiceProvider interface: GetRequiredScopedService
+- EXTENDED ServiceCollectionExtensions class in the Cuemon.Extensions.Xunit.Hosting namespace with three new extension methods for the IServiceCollection interface: AddXunitTestOutputHelperAccessor, AddXunitTestOutputHelperAccessor{T} and an overload of AddXunitTestOutputHelperAccessor
  
 Version 8.3.2
 Availability: .NET 8, .NET 6 and .NET Standard 2.0

--- a/.nuget/Cuemon.Extensions.Xunit/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Xunit/PackageReleaseNotes.txt
@@ -7,6 +7,10 @@ Availability: .NET 9, .NET 8, .NET 6 and .NET Standard 2.0
 # Improvements
 - EXTENDED TestOutputHelperExtensions class in the Cuemon.Extensions.Xunit namespace with an additional overloaded method: WriteLines
  
+# New Features
+- ADDED ITestOutputHelperAccessor interface in the Cuemon.Extensions.Xunit namespace that provides access to the ITestOutputHelper instance
+- ADDED TestOutputHelperAccessor class in the Cuemon.Extensions.Xunit namespace that provides a default implementation of the ITestOutputHelper interface
+ 
 Version 8.3.2
 Availability: .NET 8, .NET 6 and .NET Standard 2.0
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ New features:
 - FailureConverter class in the Cuemon.Extensions.Text.Json.Converters namespace to convert FailureConverter to JSON
 - FailureConverter class in the Cuemon.Xml.Serialization.Converters namespace to convert FailureConverter to XML
 - Support for System.Threading.Lock object that targets TFMs prior to .NET 9 (credits to Mark Cilia Vincenti, https://github.com/MarkCiliaVincenti/Backport.System.Threading.Lock)
+- ITestOutputHelperAccessor interface in the Cuemon.Extensions.Xunit namespace that provides access to the ITestOutputHelper instance
+- TestOutputHelperAccessor class in the Cuemon.Extensions.Xunit namespace that provides a default implementation of the ITestOutputHelper interface
+- ServiceProviderExtensions class in the Cuemon.Extensions.Xunit.Hosting namespace that consist of one extension method for the IServiceProvider interface: GetRequiredScopedService
+- ServiceCollectionExtensions class in the Cuemon.Extensions.Xunit.Hosting namespace was extended with three new extension methods for the IServiceCollection interface: AddXunitTestOutputHelperAccessor, AddXunitTestOutputHelperAccessor{T} and an overload of AddXunitTestOutputHelperAccessor
 
 ### Changed
 

--- a/src/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json.csproj
+++ b/src/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0-preview.7.24406.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0-rc.1.24452.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.DependencyInjection/Cuemon.Extensions.DependencyInjection.csproj
+++ b/src/Cuemon.Extensions.DependencyInjection/Cuemon.Extensions.DependencyInjection.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.7.24405.7" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0-rc.1.24431.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.Hosting/Cuemon.Extensions.Hosting.csproj
+++ b/src/Cuemon.Extensions.Hosting/Cuemon.Extensions.Hosting.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.1.24431.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.Net/Cuemon.Extensions.Net.csproj
+++ b/src/Cuemon.Extensions.Net/Cuemon.Extensions.Net.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0-rc.1.24431.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.Text.Json/Cuemon.Extensions.Text.Json.csproj
+++ b/src/Cuemon.Extensions.Text.Json/Cuemon.Extensions.Text.Json.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="System.Text.Json" Version="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0-rc.1.24431.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.Xunit.Hosting.AspNetCore/Cuemon.Extensions.Xunit.Hosting.AspNetCore.csproj
+++ b/src/Cuemon.Extensions.Xunit.Hosting.AspNetCore/Cuemon.Extensions.Xunit.Hosting.AspNetCore.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.0-preview.7.24406.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.0-rc.1.24452.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.Xunit.Hosting/Cuemon.Extensions.Xunit.Hosting.csproj
+++ b/src/Cuemon.Extensions.Xunit.Hosting/Cuemon.Extensions.Xunit.Hosting.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-preview.7.24405.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-preview.7.24405.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0-preview.7.24405.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.0-preview.7.24405.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0-rc.1.24431.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.Xunit.Hosting/ServiceCollectionExtensions.cs
+++ b/src/Cuemon.Extensions.Xunit.Hosting/ServiceCollectionExtensions.cs
@@ -28,7 +28,30 @@ namespace Cuemon.Extensions.Xunit.Hosting
             services.AddLogging(builder =>
             {
                 builder.SetMinimumLevel(minimumLevel);
-                builder.AddProvider(new XunitTestLoggerProvider(new TestOutputHelperAccessor(output)));
+                builder.AddProvider(new XunitTestLoggerProvider(output));
+            });
+            return services;
+        }
+
+        /// <summary>
+        /// Adds a unit test optimized implementation of output logging to the <paramref name="services"/> collection.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to extend.</param>
+        /// <param name="accessor">The <see cref="ITestOutputHelperAccessor"/> that provides access to the output for the logging.</param>
+        /// <param name="minimumLevel">The <see cref="LogLevel"/> that specifies the minimum level to include for the logging.</param>
+        /// <returns>A reference to <paramref name="services" /> so that additional configuration calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> cannot be null -or-
+        /// <paramref name="accessor"/> cannot be null.
+        /// </exception>
+        public static IServiceCollection AddXunitTestLogging(this IServiceCollection services, ITestOutputHelperAccessor accessor, LogLevel minimumLevel = LogLevel.Trace)
+        {
+            Validator.ThrowIfNull(services);
+            Validator.ThrowIfNull(accessor);
+            services.AddLogging(builder =>
+            {
+                builder.SetMinimumLevel(minimumLevel);
+                builder.AddProvider(new XunitTestLoggerProvider(accessor));
             });
             return services;
         }
@@ -38,9 +61,9 @@ namespace Cuemon.Extensions.Xunit.Hosting
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/> to extend.</param>
         /// <returns>A reference to <paramref name="services" /> so that additional configuration calls can be chained.</returns>
-        public static IServiceCollection AddTestOutputHelperAccessor(this IServiceCollection services)
+        public static IServiceCollection AddXunitTestOutputHelperAccessor(this IServiceCollection services)
         {
-            services.AddTestOutputHelperAccessor<TestOutputHelperAccessor>();
+            services.AddXunitTestOutputHelperAccessor<TestOutputHelperAccessor>();
             return services;
         }
 
@@ -53,7 +76,7 @@ namespace Cuemon.Extensions.Xunit.Hosting
         /// <exception cref="ArgumentNullException">
         /// <paramref name="services"/> cannot be null.
         /// </exception>
-        public static IServiceCollection AddTestOutputHelperAccessor<T>(this IServiceCollection services) where T : class, ITestOutputHelperAccessor
+        public static IServiceCollection AddXunitTestOutputHelperAccessor<T>(this IServiceCollection services) where T : class, ITestOutputHelperAccessor
         {
             Validator.ThrowIfNull(services);
             services.AddSingleton<ITestOutputHelperAccessor, T>();

--- a/src/Cuemon.Extensions.Xunit.Hosting/ServiceCollectionExtensions.cs
+++ b/src/Cuemon.Extensions.Xunit.Hosting/ServiceCollectionExtensions.cs
@@ -28,8 +28,35 @@ namespace Cuemon.Extensions.Xunit.Hosting
             services.AddLogging(builder =>
             {
                 builder.SetMinimumLevel(minimumLevel);
-                builder.AddProvider(new XunitTestLoggerProvider(output));
+                builder.AddProvider(new XunitTestLoggerProvider(new TestOutputHelperAccessor(output)));
             });
+            return services;
+        }
+
+        /// <summary>
+        /// Adds a default implementation of <see cref="ITestOutputHelperAccessor"/> to the <paramref name="services"/> collection.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to extend.</param>
+        /// <returns>A reference to <paramref name="services" /> so that additional configuration calls can be chained.</returns>
+        public static IServiceCollection AddTestOutputHelperAccessor(this IServiceCollection services)
+        {
+            services.AddTestOutputHelperAccessor<TestOutputHelperAccessor>();
+            return services;
+        }
+
+        /// <summary>
+        /// Adds a specified implementation of <see cref="ITestOutputHelperAccessor"/> to the <paramref name="services"/> collection.
+        /// </summary>
+        /// <typeparam name="T">The type of the implementation of <see cref="ITestOutputHelperAccessor"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> to extend.</param>
+        /// <returns>A reference to <paramref name="services" /> so that additional configuration calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> cannot be null.
+        /// </exception>
+        public static IServiceCollection AddTestOutputHelperAccessor<T>(this IServiceCollection services) where T : class, ITestOutputHelperAccessor
+        {
+            Validator.ThrowIfNull(services);
+            services.AddSingleton<ITestOutputHelperAccessor, T>();
             return services;
         }
     }

--- a/src/Cuemon.Extensions.Xunit.Hosting/XunitTestLogger.cs
+++ b/src/Cuemon.Extensions.Xunit.Hosting/XunitTestLogger.cs
@@ -1,12 +1,19 @@
 ﻿using System;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
 
 namespace Cuemon.Extensions.Xunit.Hosting
 {
     internal class XunitTestLogger : InMemoryTestStore<XunitTestLoggerEntry>, ILogger, IDisposable
     {
         private readonly ITestOutputHelperAccessor _accessor;
+        private readonly ITestOutputHelper _output;
+
+        public XunitTestLogger(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         public XunitTestLogger(ITestOutputHelperAccessor accessor)
         {
@@ -19,7 +26,14 @@ namespace Cuemon.Extensions.Xunit.Hosting
             if (exception != null) { builder.AppendLine().Append(exception).AppendLine(); }
 
             var message = builder.ToString();
-            _accessor.TestOutput.WriteLine(message);
+            if (_accessor != null)
+            {
+                _accessor.TestOutput.WriteLine(message);
+            }
+            else
+            {
+                _output.WriteLine(message);
+            }
             Add(new XunitTestLoggerEntry(logLevel, eventId, message));
         }
 

--- a/src/Cuemon.Extensions.Xunit.Hosting/XunitTestLogger.cs
+++ b/src/Cuemon.Extensions.Xunit.Hosting/XunitTestLogger.cs
@@ -1,17 +1,16 @@
 ﻿using System;
 using System.Text;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Cuemon.Extensions.Xunit.Hosting
 {
     internal class XunitTestLogger : InMemoryTestStore<XunitTestLoggerEntry>, ILogger, IDisposable
     {
-        private readonly ITestOutputHelper _output;
+        private readonly ITestOutputHelperAccessor _accessor;
 
-        public XunitTestLogger(ITestOutputHelper output)
+        public XunitTestLogger(ITestOutputHelperAccessor accessor)
         {
-            _output = output;
+            _accessor = accessor;
         }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
@@ -20,7 +19,7 @@ namespace Cuemon.Extensions.Xunit.Hosting
             if (exception != null) { builder.AppendLine().Append(exception).AppendLine(); }
 
             var message = builder.ToString();
-            _output.WriteLine(message);
+            _accessor.TestOutput.WriteLine(message);
             Add(new XunitTestLoggerEntry(logLevel, eventId, message));
         }
 

--- a/src/Cuemon.Extensions.Xunit.Hosting/XunitTestLoggerProvider.cs
+++ b/src/Cuemon.Extensions.Xunit.Hosting/XunitTestLoggerProvider.cs
@@ -1,22 +1,21 @@
 ﻿using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
-using Xunit.Abstractions;
 
 namespace Cuemon.Extensions.Xunit.Hosting
 {
     internal class XunitTestLoggerProvider : ILoggerProvider
     {
         private readonly ConcurrentDictionary<string, XunitTestLogger> _loggers = new();
-        private readonly ITestOutputHelper _output;
+        private readonly ITestOutputHelperAccessor _accessor;
 
-        public XunitTestLoggerProvider(ITestOutputHelper output)
+        public XunitTestLoggerProvider(ITestOutputHelperAccessor accessor)
         {
-            _output = output;
+            _accessor = accessor;
         }
 
         public ILogger CreateLogger(string categoryName)
         {
-            return _loggers.GetOrAdd(categoryName, s => new XunitTestLogger(_output));
+            return _loggers.GetOrAdd(categoryName, s => new XunitTestLogger(_accessor));
         }
 
         public void Dispose()

--- a/src/Cuemon.Extensions.Xunit.Hosting/XunitTestLoggerProvider.cs
+++ b/src/Cuemon.Extensions.Xunit.Hosting/XunitTestLoggerProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
+using Xunit.Abstractions;
 
 namespace Cuemon.Extensions.Xunit.Hosting
 {
@@ -7,6 +8,12 @@ namespace Cuemon.Extensions.Xunit.Hosting
     {
         private readonly ConcurrentDictionary<string, XunitTestLogger> _loggers = new();
         private readonly ITestOutputHelperAccessor _accessor;
+        private readonly ITestOutputHelper _output;
+
+        public XunitTestLoggerProvider(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         public XunitTestLoggerProvider(ITestOutputHelperAccessor accessor)
         {
@@ -15,7 +22,9 @@ namespace Cuemon.Extensions.Xunit.Hosting
 
         public ILogger CreateLogger(string categoryName)
         {
-            return _loggers.GetOrAdd(categoryName, s => new XunitTestLogger(_accessor));
+            return _loggers.GetOrAdd(categoryName, _ => _accessor != null 
+                ? new XunitTestLogger(_accessor)
+                : new XunitTestLogger(_output));
         }
 
         public void Dispose()

--- a/src/Cuemon.Extensions.Xunit/ITestOutputHelperAccessor.cs
+++ b/src/Cuemon.Extensions.Xunit/ITestOutputHelperAccessor.cs
@@ -1,0 +1,16 @@
+﻿using Xunit.Abstractions;
+
+namespace Cuemon.Extensions.Xunit
+{
+    /// <summary>
+    /// Provides an interface for accessing the <see cref="ITestOutputHelper"/> instance.
+    /// </summary>
+    public interface ITestOutputHelperAccessor
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ITestOutputHelper"/> instance used for outputting test results.
+        /// </summary>
+        /// <value>The <see cref="ITestOutputHelper"/> instance.</value>
+        ITestOutputHelper TestOutput { get; set; }
+    }
+}

--- a/src/Cuemon.Extensions.Xunit/TestOutputHelperAccessor.cs
+++ b/src/Cuemon.Extensions.Xunit/TestOutputHelperAccessor.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading;
+using Xunit.Abstractions;
+
+namespace Cuemon.Extensions.Xunit
+{
+    /// <summary>
+    /// Provides a default implementation of the <see cref="ITestOutputHelper"/> interface.
+    /// </summary>
+    public class TestOutputHelperAccessor : ITestOutputHelperAccessor
+    {
+        private static readonly AsyncLocal<ITestOutputHelper> Current = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestOutputHelperAccessor"/> class with the specified <see cref="ITestOutputHelper"/> instance.
+        /// </summary>
+        /// <param name="output">The <see cref="ITestOutputHelper"/> instance to be used for outputting test results.</param>
+        public TestOutputHelperAccessor(ITestOutputHelper output = null)
+        {
+            Current.Value = output;
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ITestOutputHelper"/> instance used for outputting test results.
+        /// </summary>
+        /// <value>The <see cref="ITestOutputHelper"/> instance.</value>
+        public ITestOutputHelper TestOutput
+        {
+            get => Current.Value;
+            set => Current.Value = value;
+        }
+    }
+}

--- a/test/Cuemon.Data.Tests/Cuemon.Data.Tests.csproj
+++ b/test/Cuemon.Data.Tests/Cuemon.Data.Tests.csproj
@@ -26,15 +26,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0-preview.7.24405.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0-rc.1.24451.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.7" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net6')) Or $(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.32" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.33" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">

--- a/test/Cuemon.Extensions.Xunit.Hosting.AspNetCore.Tests/AspNetCoreHostTestTest.cs
+++ b/test/Cuemon.Extensions.Xunit.Hosting.AspNetCore.Tests/AspNetCoreHostTestTest.cs
@@ -6,6 +6,7 @@ using Cuemon.Extensions.Xunit.Hosting.AspNetCore.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,6 +22,8 @@ namespace Cuemon.Extensions.Xunit.Hosting.AspNetCore
         {
             _pipeline = hostFixture.Application;
             _provider = hostFixture.ServiceProvider;
+            
+            _provider.GetRequiredService<ITestOutputHelperAccessor>().TestOutput = output;
         }
 
         [Fact]
@@ -44,8 +47,16 @@ namespace Cuemon.Extensions.Xunit.Hosting.AspNetCore
             Assert.False(options.Value.F);
         }
 
+        [Fact]
+        public void ShouldLogToXunitTestLogging()
+        {
+            var logger = _pipeline.ApplicationServices.GetRequiredService<ILogger<AspNetCoreHostTestTest>>();
+            logger.LogInformation("Hello from {0}", nameof(ShouldLogToXunitTestLogging));
+        }
+
         public override void ConfigureApplication(IApplicationBuilder app)
         {
+            app.ApplicationServices.GetRequiredService<ILogger<AspNetCoreHostTestTest>>().LogInformation(nameof(ConfigureApplication));
             app.UseMiddleware<BoolMiddleware>();
         }
 
@@ -58,6 +69,8 @@ namespace Cuemon.Extensions.Xunit.Hosting.AspNetCore
                 o.C = true;
                 o.E = true;
             });
+            services.AddTestOutputHelperAccessor();
+            services.AddXunitTestLogging(TestOutput);
         }
     }
 }

--- a/test/Cuemon.Extensions.Xunit.Hosting.AspNetCore.Tests/AspNetCoreHostTestTest.cs
+++ b/test/Cuemon.Extensions.Xunit.Hosting.AspNetCore.Tests/AspNetCoreHostTestTest.cs
@@ -33,7 +33,7 @@ namespace Cuemon.Extensions.Xunit.Hosting.AspNetCore
             var options = _provider.GetRequiredService<IOptions<BoolOptions>>();
             var pipeline = _pipeline.Build();
 
-            Assert.Equal("Hello awesome developers!", context.Response.Body.ToEncodedString(o => o.LeaveOpen = true));
+            Assert.Equal("Hello awesome developers!", context!.Response.Body.ToEncodedString(o => o.LeaveOpen = true));
 
             await pipeline(context);
 
@@ -69,8 +69,8 @@ namespace Cuemon.Extensions.Xunit.Hosting.AspNetCore
                 o.C = true;
                 o.E = true;
             });
-            services.AddTestOutputHelperAccessor();
-            services.AddXunitTestLogging(TestOutput);
+            services.AddXunitTestOutputHelperAccessor();
+            services.AddXunitTestLogging(new TestOutputHelperAccessor(TestOutput));
         }
     }
 }

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net6.0.425-net8.0.401-9.0.100-preview.7.24407.12"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net6.0.425-net8.0.401-9.0.100-rc.1.24452.12"
         }
     ]
 }


### PR DESCRIPTION
#### PR Classification
New feature to enhance unit test logging capabilities.

#### PR Summary
Introduces new methods and interfaces to support unit test optimized logging using `ITestOutputHelperAccessor`.
- `ServiceCollectionExtensions.cs`: Added methods `AddXunitTestLogging`, `AddXunitTestOutputHelperAccessor`, and `AddXunitTestOutputHelperAccessor<T>`,
- `XunitTestLogger.cs` and `XunitTestLoggerProvider.cs`: Updated to support `ITestOutputHelperAccessor`,
- Introduced `ITestOutputHelperAccessor` interface and `TestOutputHelperAccessor` class,
- `AspNetCoreHostTestTest.cs`: Updated to use `ITestOutputHelperAccessor` for logging and added a new test method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced enhanced logging capabilities for unit tests with new methods for configuring logging and output access.
	- Added support for flexible logging through the `ITestOutputHelperAccessor` interface.
	- Implemented a concrete class for managing `ITestOutputHelper` instances in a thread-safe manner.

- **Bug Fixes**
	- Improved robustness by adding validation checks for service configurations in logging methods.

- **Tests**
	- Added new tests to verify logging functionality within the test suite.
	- Enhanced existing tests with additional logging and service registration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->