### PR TITLE
:alembic: gha seems to have problems with .net9rc1

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -210,8 +210,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
-      - if: inputs.includePreview == 'true'
-        name: 9.0.100-preview.7.24407.12
+
+      - name: 9.0.100-preview.7.24407.12
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.100-preview.7.24407.12

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -197,10 +197,25 @@ jobs:
       - name: Checkout
         uses: codebeltnet/git-checkout@v1
 
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
+      # - name: Install .NET
+      #   uses: codebeltnet/install-dotnet@v1
+      #   with:
+      #     includePreview: true
+
+      - name: 6.0.x
+        uses: actions/setup-dotnet@v4
         with:
-          includePreview: true
+          dotnet-version: 6.0.x
+      - name: 8.0.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - if: inputs.includePreview == 'true'
+        name: 9.0.100-preview.7.24407.12
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.100-preview.7.24407.12
+          dotnet-quality: preview
 
       - name: Install .NET Tool - Report Generator
         uses: codebeltnet/dotnet-tool-install-reportgenerator@v1

--- a/src/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json.csproj
+++ b/src/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0-rc.1.24452.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0-preview.7.24406.2" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.DependencyInjection/Cuemon.Extensions.DependencyInjection.csproj
+++ b/src/Cuemon.Extensions.DependencyInjection/Cuemon.Extensions.DependencyInjection.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-rc.1.24431.7" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0-preview.7.24405.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.Hosting/Cuemon.Extensions.Hosting.csproj
+++ b/src/Cuemon.Extensions.Hosting/Cuemon.Extensions.Hosting.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-preview.7.24405.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.Net/Cuemon.Extensions.Net.csproj
+++ b/src/Cuemon.Extensions.Net/Cuemon.Extensions.Net.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0-preview.7.24405.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.Text.Json/Cuemon.Extensions.Text.Json.csproj
+++ b/src/Cuemon.Extensions.Text.Json/Cuemon.Extensions.Text.Json.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="System.Text.Json" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0-preview.7.24405.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.Xunit.Hosting.AspNetCore/Cuemon.Extensions.Xunit.Hosting.AspNetCore.csproj
+++ b/src/Cuemon.Extensions.Xunit.Hosting.AspNetCore/Cuemon.Extensions.Xunit.Hosting.AspNetCore.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.0-rc.1.24452.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.0-preview.7.24406.2" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/src/Cuemon.Extensions.Xunit.Hosting/Cuemon.Extensions.Xunit.Hosting.csproj
+++ b/src/Cuemon.Extensions.Xunit.Hosting/Cuemon.Extensions.Xunit.Hosting.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.1.24431.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.1.24431.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0-rc.1.24431.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.0-rc.1.24431.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0-preview.7.24405.7" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">

--- a/test/Cuemon.Data.Tests/Cuemon.Data.Tests.csproj
+++ b/test/Cuemon.Data.Tests/Cuemon.Data.Tests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0-rc.1.24451.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0-preview.7.24405.3" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">


### PR DESCRIPTION
#### PR Classification
Update to .NET installation process in CI pipeline.

#### PR Summary
Updated the .NET installation step to use a newer action and specified versions.
- `.github/workflows/ci.yml`: Replaced `codebeltnet/install-dotnet@v1` with `actions/setup-dotnet@v4`.
- `.github/workflows/ci.yml`: Added installation of .NET versions `6.0.x`, `8.0.x`, and conditional preview version `9.0.100-preview.7.24407.12`.
- `.github/workflows/ci.yml`: Set `dotnet-quality` parameter to `preview` for the preview version.

Problem discovered for:

- Cuemon.AspNetCore.Mvc.FunctionalTests
- Cuemon.AspNetCore.Mvc.Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced workflow flexibility by allowing installation of specific .NET versions, including a preview version based on user input.

- **Bug Fixes**
	- Improved compatibility and testing capabilities with updated installation methods for .NET.
	- Updated various package references to preview versions, potentially introducing new features and bug fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->