### PR TITLE
:alembic: .net9rc1 fails on gha ubuntu 22.04; experiment with 24.04

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   prepare_linux:
     name: 🐧 Prepare Linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
       restoreCacheKey: ${{ steps.dotnet-restore.outputs.restoreCacheKey }}
@@ -64,7 +64,7 @@ jobs:
 
   build:
     name: 🛠️ Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -159,7 +159,7 @@ jobs:
 
   pack:
     name: 📦 Pack
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -188,7 +188,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-24.04, windows-2022]
         configuration: [Debug, Release]
         project: ${{ fromJson(needs.build.outputs.testProjects) }}
     runs-on: ${{ matrix.os }}
@@ -240,7 +240,7 @@ jobs:
   sonarcloud:
     name: 🔬 Code Quality Analysis
     needs: [prepare_linux, build, test]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -282,7 +282,7 @@ jobs:
   codecov:
     name: 📊 Code Coverage Analysis
     needs: [build, test]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -297,7 +297,7 @@ jobs:
   codeql:
     name: 🛡️ Security Analysis
     needs: [prepare_linux, build, test]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -329,7 +329,7 @@ jobs:
   deploy:
     if: github.event_name != 'pull_request'
     name: 🚀 Deploy v${{ needs.build.outputs.version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [build, pack, test, sonarcloud, codecov, codeql]
     environment: Production


### PR DESCRIPTION
#### PR Classification
Update CI configuration to use a newer Ubuntu version.

#### PR Summary
Updated the `runs-on` parameter in `pipelines.yml` to use `ubuntu-24.04` for various jobs.
- `pipelines.yml`: Changed `runs-on` from `ubuntu-22.04` to `ubuntu-24.04` for `prepare_linux`, `build`, `pack`, `test`, `sonarcloud`, `codecov`, `codeql`, and `deploy` jobs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the GitHub Actions workflow to utilize Ubuntu 24.04, potentially enhancing performance and security across all jobs.
- **Bug Fixes**
	- Improved compatibility with updated dependencies and libraries by transitioning to the latest operating system version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->