### PR TITLE
:alembic: experimental change to avoid potential deadlock

### DIFF
--- a/src/Cuemon.Extensions.Xunit.Hosting.AspNetCore/AspNetCoreHostFixture.cs
+++ b/src/Cuemon.Extensions.Xunit.Hosting.AspNetCore/AspNetCoreHostFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using Cuemon.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -88,7 +89,9 @@ namespace Cuemon.Extensions.Xunit.Hosting.AspNetCore
                 o.ValidateScopes = true;
             });
 
-            Host = hb.Start();
+            var host = hb.Build();
+            Task.Run(() => host.StartAsync()).GetAwaiter().GetResult();
+            Host = host;
         }
 
         /// <summary>

--- a/test/Cuemon.AspNetCore.Mvc.FunctionalTests/Cuemon.AspNetCore.Mvc.FunctionalTests.csproj
+++ b/test/Cuemon.AspNetCore.Mvc.FunctionalTests/Cuemon.AspNetCore.Mvc.FunctionalTests.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" Version="2.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Cuemon.AspNetCore.Mvc\Cuemon.AspNetCore.Mvc.csproj" />
     <ProjectReference Include="..\..\src\Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json\Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json.csproj" />
     <ProjectReference Include="..\..\src\Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json\Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json.csproj" />

--- a/test/Cuemon.AspNetCore.Mvc.Tests/xunit.runner.json
+++ b/test/Cuemon.AspNetCore.Mvc.Tests/xunit.runner.json
@@ -1,3 +1,0 @@
-﻿{
-  "shadowCopy": false
-}


### PR DESCRIPTION
#### PR Classification
Code improvement to introduce asynchronous host starting (and hopefully prevent deadlock as highlighted [in this article](https://www.strathweb.com/2021/05/the-curious-case-of-asp-net-core-integration-test-deadlock/).

#### PR Summary
Modified the `AspNetCoreHostFixture` class to start the host asynchronously.
- Added `System.Threading.Tasks` namespace,
- Changed host initialization to use `Task.Run(() => host.StartAsync()).GetAwaiter().GetResult()` instead of `hb.Start()`.

Reason for change paired with referenced article: https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostBuilderExtensions.cs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced asynchronous host startup for improved scalability and responsiveness in ASP.NET Core applications.
  
- **Bug Fixes**
	- Removed the `Meziantou.Xunit.ParallelTestFramework` package, potentially altering the testing strategy.

- **Chores**
	- Deleted `xunit.runner.json` configuration file, indicating a shift in test environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->