### PR TITLE
V9.0.0/housekeeping for extensions globalization

### DIFF
--- a/.docfx/api/namespaces/Cuemon.Extensions.Globalization.md
+++ b/.docfx/api/namespaces/Cuemon.Extensions.Globalization.md
@@ -2,11 +2,11 @@
 uid: Cuemon.Extensions.Globalization
 summary: *content
 ---
-The `Cuemon.Extensions.Globalization` namespace contains extension methods that complements the `Cuemon.Globalization` namespace while being an addition to the `System.Globalization` namespace.
+The `Cuemon.Extensions.Globalization`  namespace contains extension methods that is an addition to the `System.Globalization` namespace.
 
 [!INCLUDE [availability-default](../../includes/availability-default.md)]
 
-Complements: [Cuemon.Globalization namespace](/api/dotnet/Cuemon.Globalization.html) 📘
+Complements: [System.Globalization namespace](https://docs.microsoft.com/en-us/dotnet/api/system.globalization) 🔗
 
 ### Extension Methods
 
@@ -15,9 +15,10 @@ Complements: [Cuemon.Globalization namespace](/api/dotnet/Cuemon.Globalization.h
 |CultureInfo|⬇️|`UseNationalLanguageSupport`|
 
 ### CSharp Example
+
 ```csharp
-var danishCultureIcu = CultureInfo("da-dk");
-var danishCultureNls = new CultureInfo("da-dk").UseNationalLanguageSupport();
+var danishCultureIcu = new CultureInfo("da-dk", false);
+var danishCultureNls = new CultureInfo("da-dk", false).UseNationalLanguageSupport();
 
 // danishCultureIcu outputs dd.MM.yyyy from danishCultureIcu.DateTimeFormat.ShortDatePattern
 // danishCultureNls outputs dd-MM-yyyy from danishCultureNls.DateTimeFormat.ShortDatePattern

--- a/.nuget/Cuemon.Extensions.Globalization/README.md
+++ b/.nuget/Cuemon.Extensions.Globalization/README.md
@@ -7,11 +7,23 @@ It is, by heart, free, flexible and built to extend and boost your agile codebel
 
 ## **Cuemon.Extensions.Globalization** for .NET
 
-The `Cuemon.Extensions.Globalization` namespace contains extension methods that complements the Cuemon.Globalization namespace while being an addition to the System.Globalization namespace.
+The `Cuemon.Extensions.Globalization` namespace contains extension methods that is an addition to the `System.Globalization` namespace.
+
+It aims to provide a way to favor National Language Support (NLS) over International Components for Unicode (ICU).
 
 More documentation available at our documentation site:
 
 - [Cuemon for .NET documentation](https://docs.cuemon.net/api/extensions/dotnet/Cuemon.Extensions.Globalization.html) 🔗
+
+### CSharp Example
+
+```csharp
+var danishCultureIcu = new CultureInfo("da-dk", false);
+var danishCultureNls = new CultureInfo("da-dk", false).UseNationalLanguageSupport();
+
+// danishCultureIcu outputs dd.MM.yyyy from danishCultureIcu.DateTimeFormat.ShortDatePattern
+// danishCultureNls outputs dd-MM-yyyy from danishCultureNls.DateTimeFormat.ShortDatePattern
+```
 
 ## Related Packages
 

--- a/src/Cuemon.Extensions.Globalization/Cuemon.Extensions.Globalization.csproj
+++ b/src/Cuemon.Extensions.Globalization/Cuemon.Extensions.Globalization.csproj
@@ -1204,9 +1204,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cuemon.Core\Cuemon.Core.csproj" />
     <ProjectReference Include="..\Cuemon.Extensions.Reflection\Cuemon.Extensions.Reflection.csproj" />
-    <ProjectReference Include="..\Cuemon.Extensions.IO\Cuemon.Extensions.IO.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Cuemon.Extensions.Globalization/CultureInfoExtensions.cs
+++ b/src/Cuemon.Extensions.Globalization/CultureInfoExtensions.cs
@@ -59,15 +59,26 @@ namespace Cuemon.Extensions.Globalization
                 {
                     var surrogate = typeof(CultureInfoExtensions).GetEmbeddedResources($"{culture.Name}.bin", ManifestResourceMatch.ContainsName).SingleOrDefault();
                     var ms = new MemoryStream(surrogate.Value.DecompressGZip().ToByteArray());
-                    var suggogateCulture = YamlFormatter.DeserializeObject<CultureInfoSurrogate>(ms, o =>
+                    var surrogateCulture = YamlFormatter.DeserializeObject<CultureInfoSurrogate>(ms, o =>
                     {
                         o.Settings.NamingConvention = NullNamingConvention.Instance;
                         o.Settings.ReflectionRules = new MemberReflection();
                         o.Settings.IndentSequences = false;
                     });
-                    Enrich(culture, suggogateCulture);
-                    EnrichedCultureInfos.Add(culture);
-                    enrichedCultures.Add(culture);
+
+                    if (culture.IsReadOnly)
+                    {
+                        var cultureClone = culture.Clone() as CultureInfo;
+                        Enrich(cultureClone, surrogateCulture);
+                        EnrichedCultureInfos.Add(cultureClone);
+                        enrichedCultures.Add(cultureClone);
+                    }
+                    else
+                    {
+                        Enrich(culture, surrogateCulture);
+                        EnrichedCultureInfos.Add(culture);
+                        enrichedCultures.Add(culture);
+                    }
                 }
             }
             return enrichedCultures;

--- a/test/Cuemon.Extensions.Globalization.Tests/CultureInfoExtensionsTest.cs
+++ b/test/Cuemon.Extensions.Globalization.Tests/CultureInfoExtensionsTest.cs
@@ -1,18 +1,41 @@
 ﻿using System.Globalization;
-using System.Linq;
+using System.Runtime.InteropServices;
 using Codebelt.Extensions.Xunit;
-using Cuemon.Globalization;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Cuemon.Extensions.Globalization
 {
     public class CultureInfoExtensionsTest : Test
     {
-        [Fact]
-        public void MergeWithOriginal_ShouldHaveDifferentFormattingAsWindowsVariant()
+        public CultureInfoExtensionsTest(ITestOutputHelper output) : base(output)
         {
-            var sut1 = World.GetCultures(new RegionInfo("DK")).Single(ci => ci.Name == "da-DK");
-            var sut2 = new CultureInfo("da-dk").UseNationalLanguageSupport();
+        }
+
+        [Fact]
+        public void UseNationalLanguageSupport_ShouldHaveDifferentFormattingAsWindowsVariant()
+        {
+            var sut1 = new CultureInfo("da-DK", false);
+            var sut2 = (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                        ? new CultureInfo("da-DK") // Linux uses ICU
+                        : new CultureInfo("da-DK", false) // Ensure we do not read from user culture settings on Windows
+                ).UseNationalLanguageSupport();
+
+            Assert.NotEqual(sut1.DateTimeFormat, sut2.DateTimeFormat);
+            Assert.NotEqual(sut1.NumberFormat, sut2.NumberFormat);
+#if NET48_OR_GREATER
+            Assert.Equal(sut1.DateTimeFormat.ShortDatePattern, sut2.DateTimeFormat.ShortDatePattern);
+#else
+            Assert.Equal("dd.MM.yyyy", sut1.DateTimeFormat.ShortDatePattern);
+            Assert.Equal("dd-MM-yyyy", sut2.DateTimeFormat.ShortDatePattern);
+#endif
+        }
+
+        [Fact]
+        public void UseNationalLanguageSupport_ShouldHaveDifferentFormattingAsWindowsVariant_FromReadOnlyCultureInfos()
+        {
+            var sut1 = CultureInfo.GetCultureInfo("da-DK");
+            var sut2 = CultureInfo.GetCultureInfo("da-DK").UseNationalLanguageSupport();
 
             Assert.NotEqual(sut1.DateTimeFormat, sut2.DateTimeFormat);
             Assert.NotEqual(sut1.NumberFormat, sut2.NumberFormat);


### PR DESCRIPTION
#### PR Classification
Documentation and code enhancement.

#### PR Summary
Improved documentation, examples, and handling of `CultureInfo` objects, and enhanced test coverage,
- **Cuemon.Extensions.Globalization.md**: Clarified namespace purpose and updated examples,
- **CultureInfoExtensions.cs**: Fixed typo and added logic for read-only `CultureInfo` objects,
- **CultureInfoExtensionsTest.cs**: Added new test and updated existing tests for better coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for the `Cuemon.Extensions.Globalization` namespace to clarify its relationship with `System.Globalization`.
	- Added examples demonstrating the use of National Language Support (NLS) versus International Components for Unicode (ICU).
- **Bug Fixes**
	- Improved handling of `CultureInfo` objects in the `UseNationalLanguageSupport` method to preserve immutability for read-only cultures.
- **Tests**
	- Introduced new tests for national language support formatting differences across platforms.
	- Renamed and updated existing tests for clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->