### PR TITLE
V9.0.0/cpm

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,8 +47,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'false'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
-    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
+    <PackageReference Include="MinVer" PrivateAssets="all" />
     <None Include="..\..\.nuget\icon.png" Pack="true" Visible="false" PackagePath="icon.png" />
     <None Include="..\..\.nuget\$(MSBuildProjectName)\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
@@ -74,26 +74,26 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.10.0" Condition="$(TargetFramework.StartsWith('net4')) AND '$(IsLinux)' == 'true'" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Condition="$(TargetFramework.StartsWith('net4')) AND '$(IsLinux)' == 'true'" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.console" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageReference Include="Codebelt.Extensions.Xunit" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,66 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="AutoFixture" Version="4.18.1" />
+    <PackageVersion Include="Backport.System.Threading.Lock" Version="2.0.5" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="9.0.0-preview.11" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting" Version="9.0.0-preview.11" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageVersion Include="Codebelt.Extensions.YamlDotNet" Version="9.0.0-preview.5" />
+    <PackageVersion Include="Meziantou.Xunit.ParallelTestFramework" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.10.0" />
+    <PackageVersion Include="MinVer" Version="6.0.0" />
+    <PackageVersion Include="NativeLibraryLoader" Version="1.0.13" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageVersion Include="Xunit.Priority" Version="1.1.6" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.console" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="6.0.35" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.0-rc.2.24474.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-rc.2.24473.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.2.24473.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0-rc.2.24473.5" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0-rc.2.24473.5" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.2.24473.5" />
+  </ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 # Cuemon for .NET
 
 An open-source project (MIT license) that targets and complements the Microsoft .NET platform. It provides vast ways of possibilities for all breeds of coders, programmers, developers and the likes thereof.
-Your ideal companion for .NET 8, .NET 6, .NET Standard 2 and .NET Framework 4.6.2 and newer.
+Your ideal companion for modern .NET 9, .NET 8, .NET Standard 2 including legacy .NET Framework 4.6.2 and newer.
 
 It is, by heart, free, flexible and built to extend and boost your agile codebelt.
 
 ## State of the Union
 
-Cuemon for .NET (formerly Cuemon .NET Standard) has been completely refactored and updated to support .NET 8 (LTS) and .NET 6 (LTS).
+Cuemon for .NET (formerly Cuemon .NET Standard) has been completely refactored and updated to support .NET 9 (STS) and .NET 8 (LTS).
 
 Support for .NET Core 3.0, .NET Core 3.1, .NET 5 and .NET 7 has been deprecated as these are out of [support](https://endoflife.date/dotnet). 
 

--- a/src/Cuemon.Data.SqlClient/Cuemon.Data.SqlClient.csproj
+++ b/src/Cuemon.Data.SqlClient/Cuemon.Data.SqlClient.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Data.SqlClient" />
   </ItemGroup>
 
 </Project>

--- a/src/Cuemon.Extensions.Core/Cuemon.Extensions.Core.csproj
+++ b/src/Cuemon.Extensions.Core/Cuemon.Extensions.Core.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cuemon.Extensions.DependencyInjection/Cuemon.Extensions.DependencyInjection.csproj
+++ b/src/Cuemon.Extensions.DependencyInjection/Cuemon.Extensions.DependencyInjection.csproj
@@ -9,19 +9,9 @@
     <PackageTags>extension-methods extensions add tryadd</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0-rc.2.24473.5" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cuemon.Extensions.Globalization/Cuemon.Extensions.Globalization.csproj
+++ b/src/Cuemon.Extensions.Globalization/Cuemon.Extensions.Globalization.csproj
@@ -1200,7 +1200,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.YamlDotNet" Version="9.0.0-preview.5" />
+    <PackageReference Include="Codebelt.Extensions.YamlDotNet" />
   </ItemGroup>
 
 </Project>

--- a/src/Cuemon.Extensions.Hosting/Cuemon.Extensions.Hosting.csproj
+++ b/src/Cuemon.Extensions.Hosting/Cuemon.Extensions.Hosting.csproj
@@ -9,16 +9,8 @@
     <PackageTags>extension-methods extensions local-development non-production host hosting</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.2.24473.5" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cuemon.Extensions.Net/Cuemon.Extensions.Net.csproj
+++ b/src/Cuemon.Extensions.Net/Cuemon.Extensions.Net.csproj
@@ -9,16 +9,8 @@
     <PackageTags>extension-methods extensions to-signed-uri validate-signed-uri http-manager-factory slim-http-client-factory i-http-client-factory</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0-rc.2.24473.5" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cuemon.Extensions.Text.Json/Cuemon.Extensions.Text.Json.csproj
+++ b/src/Cuemon.Extensions.Text.Json/Cuemon.Extensions.Text.Json.csproj
@@ -10,17 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Cuemon.Core\Cuemon.Core.csproj" />
     <ProjectReference Include="..\Cuemon.IO\Cuemon.IO.csproj" />
     <ProjectReference Include="..\Cuemon.Diagnostics\Cuemon.Diagnostics.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="System.Text.Json" Version="9.0.0-rc.2.24473.5" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2')) or $(TargetFramework.StartsWith('net8'))">
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Cuemon.Extensions.Threading/Cuemon.Extensions.Threading.csproj
+++ b/src/Cuemon.Extensions.Threading/Cuemon.Extensions.Threading.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cuemon.Threading\Cuemon.Threading.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Backport.System.Threading.Lock" Version="2.0.5" />
+    <PackageReference Include="Backport.System.Threading.Lock" />
     <Using Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="System.Threading.Lock" />
     <Using Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="Backport.System.Threading.Lock" />
     <Using Alias="LockFactory" Include="Backport.System.Threading.LockFactory" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Cuemon.Threading\Cuemon.Threading.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.AspNetCore.Authentication.Tests/Cuemon.AspNetCore.Authentication.Tests.csproj
+++ b/test/Cuemon.AspNetCore.Authentication.Tests/Cuemon.AspNetCore.Authentication.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.AspNetCore.FunctionalTests/Cuemon.AspNetCore.FunctionalTests.csproj
+++ b/test/Cuemon.AspNetCore.FunctionalTests/Cuemon.AspNetCore.FunctionalTests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" Version="2.3.0" />
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Cuemon.AspNetCore.Mvc.FunctionalTests/Cuemon.AspNetCore.Mvc.FunctionalTests.csproj
+++ b/test/Cuemon.AspNetCore.Mvc.FunctionalTests/Cuemon.AspNetCore.Mvc.FunctionalTests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" Version="2.3.0" />
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Cuemon.AspNetCore.Mvc.FunctionalTests/Filters/Diagnostics/FaultDescriptorFilterTest.cs
+++ b/test/Cuemon.AspNetCore.Mvc.FunctionalTests/Filters/Diagnostics/FaultDescriptorFilterTest.cs
@@ -553,7 +553,7 @@ namespace Cuemon.AspNetCore.Mvc.Filters.Diagnostics
             }
         }
 
-       
+
 
         [Theory]
         [InlineData(FaultSensitivityDetails.All)]

--- a/test/Cuemon.AspNetCore.Mvc.Tests/Cuemon.AspNetCore.Mvc.Tests.csproj
+++ b/test/Cuemon.AspNetCore.Mvc.Tests/Cuemon.AspNetCore.Mvc.Tests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/Cuemon.AspNetCore.Razor.TagHelpers.Tests.csproj
+++ b/test/Cuemon.AspNetCore.Razor.TagHelpers.Tests/Cuemon.AspNetCore.Razor.TagHelpers.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.AspNetCore.Tests/Cuemon.AspNetCore.Tests.csproj
+++ b/test/Cuemon.AspNetCore.Tests/Cuemon.AspNetCore.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Core.Tests/Cuemon.Core.Tests.csproj
+++ b/test/Cuemon.Core.Tests/Cuemon.Core.Tests.csproj
@@ -15,12 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="NativeLibraryLoader" Version="1.0.13" />
+    <PackageReference Include="AutoFixture" />
+    <PackageReference Include="NativeLibraryLoader" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Cuemon.Data.SqlClient.Tests/Cuemon.Data.SqlClient.Tests.csproj
+++ b/test/Cuemon.Data.SqlClient.Tests/Cuemon.Data.SqlClient.Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Data.Tests/Cuemon.Data.Tests.csproj
+++ b/test/Cuemon.Data.Tests/Cuemon.Data.Tests.csproj
@@ -25,26 +25,19 @@
     <EmbeddedResource Include="Assets\Professional.xml" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0-rc.2.24474.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.35" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting" />
   </ItemGroup>
   
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cuemon.Data\Cuemon.Data.csproj" />
     <ProjectReference Include="..\..\src\Cuemon.Extensions.Core\Cuemon.Extensions.Core.csproj" />
@@ -54,10 +47,6 @@
     <ProjectReference Include="..\..\src\Cuemon.Extensions.Text.Json\Cuemon.Extensions.Text.Json.csproj" />
     <ProjectReference Include="..\..\src\Cuemon.IO\Cuemon.IO.csproj" />
     <ProjectReference Include="..\..\src\Cuemon.Resilience\Cuemon.Resilience.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting" Version="9.0.0-preview.11" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Extensions.AspNetCore.Authentication.Tests/Cuemon.Extensions.AspNetCore.Authentication.Tests.csproj
+++ b/test/Cuemon.Extensions.AspNetCore.Authentication.Tests/Cuemon.Extensions.AspNetCore.Authentication.Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json.Tests/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json.Tests.csproj
+++ b/test/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json.Tests/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml.Tests/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml.Tests.csproj
+++ b/test/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml.Tests/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Extensions.AspNetCore.Mvc.RazorPages.Tests/Cuemon.Extensions.AspNetCore.Mvc.RazorPages.Tests.csproj
+++ b/test/Cuemon.Extensions.AspNetCore.Mvc.RazorPages.Tests/Cuemon.Extensions.AspNetCore.Mvc.RazorPages.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Extensions.AspNetCore.Mvc.Tests/Cuemon.Extensions.AspNetCore.Mvc.Tests.csproj
+++ b/test/Cuemon.Extensions.AspNetCore.Mvc.Tests/Cuemon.Extensions.AspNetCore.Mvc.Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Extensions.AspNetCore.Tests/Cuemon.Extensions.AspNetCore.Tests.csproj
+++ b/test/Cuemon.Extensions.AspNetCore.Tests/Cuemon.Extensions.AspNetCore.Tests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Extensions.Hosting.Tests/Cuemon.Extensions.Hosting.Tests.csproj
+++ b/test/Cuemon.Extensions.Hosting.Tests/Cuemon.Extensions.Hosting.Tests.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Extensions.Net.Tests/Cuemon.Extensions.Net.Tests.csproj
+++ b/test/Cuemon.Extensions.Net.Tests/Cuemon.Extensions.Net.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Cuemon.Extensions.Runtime.Caching.Tests/Cuemon.Extensions.Runtime.Caching.Tests.csproj
+++ b/test/Cuemon.Extensions.Runtime.Caching.Tests/Cuemon.Extensions.Runtime.Caching.Tests.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Net.Tests/Cuemon.Net.Tests.csproj
+++ b/test/Cuemon.Net.Tests/Cuemon.Net.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Cuemon.Resilience.Tests/Cuemon.Resilience.Tests.csproj
+++ b/test/Cuemon.Resilience.Tests/Cuemon.Resilience.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Cuemon.Runtime.Caching.Tests/Cuemon.Runtime.Caching.Tests.csproj
+++ b/test/Cuemon.Runtime.Caching.Tests/Cuemon.Runtime.Caching.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xunit.Priority" Version="1.1.6" />
+    <PackageReference Include="Xunit.Priority" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting" Version="9.0.0-preview.11" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.Hosting" />
   </ItemGroup>
 
 </Project>

--- a/test/Cuemon.Xml.Tests/Cuemon.Xml.Tests.csproj
+++ b/test/Cuemon.Xml.Tests/Cuemon.Xml.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tooling/gse/gse.csproj
+++ b/tooling/gse/gse.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.YamlDotNet" Version="9.0.0-preview.5" PrivateAssets="all" />
+    <PackageReference Include="Codebelt.Extensions.YamlDotNet" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request includes several updates to package references across multiple project files to centralize and simplify version management. The most important changes involve removing explicit version numbers from `PackageReference` elements and adding a new `Directory.Packages.props` file to manage package versions centrally.

Centralization of package version management:

* Added `Directory.Packages.props` to manage package versions centrally, including versions for `AutoFixture`, `Microsoft.NET.Test.Sdk`, `System.Text.Json`, and others.

Simplification of package references:

* Removed version numbers from `PackageReference` elements in `Directory.Build.props` for both non-test and test projects. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL50-R51) [[2]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL77-R96)
* Removed version numbers from `PackageReference` elements in various project files, including `Cuemon.Data.SqlClient.csproj`, `Cuemon.Extensions.Core.csproj`, `Cuemon.Extensions.DependencyInjection.csproj`, `Cuemon.Extensions.Hosting.csproj`, `Cuemon.Extensions.Net.csproj`, and `Cuemon.Extensions.Text.Json.csproj`. [[1]](diffhunk://#diff-925d86057754f5e125749d272ee0e0cdf2127196dbd7b4bbda5c8670ffa77d03L18-R18) [[2]](diffhunk://#diff-be70435325c9b99f4a3d73dbe2634bf7f429b09eaf05c7f075f3a0dd17464bb7L17-R18) [[3]](diffhunk://#diff-e6aa5372d19634d07da32c030bdb95968ceb23cd14651a03a547b0b4bd58d4a1L12-R14) [[4]](diffhunk://#diff-6e549fe464d0761bac1b7f9dac57c942d9b8415fafa51b91a4b47aa8d7a200d4L12-R13) [[5]](diffhunk://#diff-5c454d3814b6be08123accf43c55fb65f1cf00de97df7466a9ffbe7e599b1c9cL12-R13) [[6]](diffhunk://#diff-6c2cc6601bd841fcdaf06a88ad8eb96ed8e8d4b41175c49e635e13c634146c04R12-L25)

Updates to README:

* Updated `README.md` to reflect support for .NET 9 and deprecation of older .NET versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced centralized package version management with the new `Directory.Packages.props` file.
	- Updated project support to include .NET 9 and .NET 8, while deprecating earlier versions.
	- Enhanced testing capabilities with new XML response handling in fault descriptor tests.

- **Bug Fixes**
	- Removed specific version constraints for various package references across multiple project files, allowing for the latest versions to be used.

- **Documentation**
	- Updated `README.md` to reflect new branching strategy and framework support changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->