### PR TITLE
Bump Backport.System.Threading.Lock to 3.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
-    <PackageVersion Include="Backport.System.Threading.Lock" Version="2.0.7" />
+    <PackageVersion Include="Backport.System.Threading.Lock" Version="3.1.0" />
     <PackageVersion Include="Codebelt.Extensions.Xunit" Version="9.0.0" />
     <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting" Version="9.0.0" />
     <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="9.0.0" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `Backport.System.Threading.Lock` package from `2.0.7` to `3.1.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->