### PR TITLE
V9.0.9/service pack

### DIFF
--- a/.docfx/Dockerfile.docfx
+++ b/.docfx/Dockerfile.docfx
@@ -1,4 +1,4 @@
-﻿ARG NGINX_VERSION=1.29.0-alpine
+﻿ARG NGINX_VERSION=1.29.1-alpine
 
 FROM --platform=$BUILDPLATFORM nginx:${NGINX_VERSION} AS base
 RUN rm -rf /usr/share/nginx/html/*

--- a/.nuget/Cuemon.AspNetCore.App/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.AspNetCore.App/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.AspNetCore.Authentication/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.AspNetCore.Authentication/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.AspNetCore.Mvc/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.AspNetCore.Mvc/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.AspNetCore.Razor.TagHelpers/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.AspNetCore.Razor.TagHelpers/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.AspNetCore/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.AspNetCore/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.Core.App/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Core.App/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Core/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Core/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Data.Integrity/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Data.Integrity/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Data.SqlClient/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Data.SqlClient/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Diagnostics/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Diagnostics/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.AspNetCore.Authentication/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Authentication/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.Extensions.AspNetCore.Mvc.RazorPages/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Mvc.RazorPages/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.Extensions.AspNetCore.Mvc/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Mvc/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.Extensions.AspNetCore.Text.Json/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Text.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.Extensions.AspNetCore.Xml/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore.Xml/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.Extensions.AspNetCore/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.AspNetCore/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Collections.Generic/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Collections.Generic/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Collections.Specialized/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Collections.Specialized/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Core/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Core/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Data.Integrity/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Data.Integrity/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Data/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Data/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.DependencyInjection/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.DependencyInjection/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Diagnostics/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Diagnostics/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Hosting/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Hosting/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.IO/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.IO/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8, .NET Standard 2.1 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8, .NET Standard 2.1 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Net/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Net/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Reflection/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Reflection/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Runtime.Caching/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Runtime.Caching/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Text.Json/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Text.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Text/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Text/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Threading/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Threading/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Extensions.Xml/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Extensions.Xml/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.IO/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.IO/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8, .NET Standard 2.1 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8, .NET Standard 2.1 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Net/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Net/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Resilience/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Resilience/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Runtime.Caching/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Runtime.Caching/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Security.Cryptography/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Security.Cryptography/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Threading/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Threading/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/.nuget/Cuemon.Xml/PackageReleaseNotes.txt
+++ b/.nuget/Cuemon.Xml/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.8
+﻿Version 9.0.9
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.8
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 For more details, please refer to `PackageReleaseNotes.txt` on a per assembly basis in the `.nuget` folder.
 
+## [9.0.9] - 2025-09-13
+
+This is a service update that focuses on package dependencies.
+
 ## [9.0.8] - 2025-08-07
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
   <ItemGroup>
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="Backport.System.Threading.Lock" Version="3.1.4" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.4" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting" Version="10.0.4" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="10.0.4" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.5" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting" Version="10.0.5" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.Hosting.AspNetCore" Version="10.0.5" />
     <PackageVersion Include="Meziantou.Xunit.ParallelTestFramework" Version="2.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.14.1" />
@@ -18,7 +18,7 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.19" />
@@ -35,20 +35,20 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) OR $(TargetFramework.StartsWith('netstandard2'))">
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.20" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8')) OR $(TargetFramework.StartsWith('net9'))">
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.1" />
   </ItemGroup>
 </Project>

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:mono-net8.0.413-9.0.304"
+            "dockerImage": "gimlichael/ubuntu-testrunner:mono-net8.0.414-9.0.305"
         }
     ]
 }


### PR DESCRIPTION
This pull request updates multiple NuGet package release notes to version 9.0.9 and documents that dependencies have been updated to their latest versions with respect to supported target frameworks (TFMs). Additionally, the NGINX base image version is bumped in the DocFX Dockerfile.

Dependency and Documentation Updates:

* Updated release notes for all relevant NuGet packages to version 9.0.9, noting availability for .NET 9, .NET 8, and in some cases .NET Standard 2.0, and documenting that dependencies have been updated to the latest versions for their respective TFMs. (.nuget/Cuemon.AspNetCore.App/PackageReleaseNotes.txt [[1]](diffhunk://#diff-c39ba600c1a0c1d15c78d996e408e4e19543cc08bf1fa9f87b21b104325d0ce6L1-R7) .nuget/Cuemon.AspNetCore.Authentication/PackageReleaseNotes.txt [[2]](diffhunk://#diff-33552699ee225fb4d6a0b5b7c74b15075137c4e7595f30ebb5f4e7aca2a1a734L1-R7) .nuget/Cuemon.AspNetCore.Mvc/PackageReleaseNotes.txt [[3]](diffhunk://#diff-5008d0251870c2bd4630fd6c2d8e9ee8caefc784f4e2e843c9114b4e5ddfb74dL1-R7) .nuget/Cuemon.AspNetCore.Razor.TagHelpers/PackageReleaseNotes.txt [[4]](diffhunk://#diff-cc07e5a6eeb151802eb6f7ad64a0654b01736c3cfefbb4304e02d4c2f393ac65L1-R7) .nuget/Cuemon.AspNetCore/PackageReleaseNotes.txt [[5]](diffhunk://#diff-dc336ee2d0f98b69176806c2329259b920b81536fb1939055cb787f85b9861baL1-R7) .nuget/Cuemon.Core.App/PackageReleaseNotes.txt [[6]](diffhunk://#diff-b593084df52362edff73eb7647eb4447d286a35dca1a5a37a61e011c33192b2cL1-R7) .nuget/Cuemon.Core/PackageReleaseNotes.txt [[7]](diffhunk://#diff-feb040adcf7b111053894f08adeacd5983e97f41bf09fda14f75596f0cfd164eL1-R7) .nuget/Cuemon.Data.Integrity/PackageReleaseNotes.txt [[8]](diffhunk://#diff-ab0b535dfd0c6ba321e5bfbcab3ab5f8f5943f4c216fdf0f56d128291aa4ccefL1-R7) .nuget/Cuemon.Data.SqlClient/PackageReleaseNotes.txt [[9]](diffhunk://#diff-30ba642f105d9f35bba22ae6352e838aa678efb57cf77bcc70ee4bfdb0b41fe7L1-R7) .nuget/Cuemon.Diagnostics/PackageReleaseNotes.txt [[10]](diffhunk://#diff-6a544da2243d4657986d8a70c3a91d19e97ad4ca0e716b897976b683d0acd7ebL1-R7) .nuget/Cuemon.Extensions.AspNetCore.Authentication/PackageReleaseNotes.txt [[11]](diffhunk://#diff-2bd9a7cbab4508603bbd82f31fd86b43ace0a15d36ef77d842058ee2794f1d8bL1-R7) .nuget/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json/PackageReleaseNotes.txt [[12]](diffhunk://#diff-1e02ec80942a6c43b840e297b8da28c305b9fadaf60715def46220cdfd5ba0e9L1-R7) .nuget/Cuemon.Extensions.AspNetCore.Mvc.Formatters.Xml/PackageReleaseNotes.txt [[13]](diffhunk://#diff-299bdd6f4b27e35a3ecc42ccdd402948a5c0de641d006675f9eecf8354438e8aL1-R7) .nuget/Cuemon.Extensions.AspNetCore.Mvc.RazorPages/PackageReleaseNotes.txt [[14]](diffhunk://#diff-b204659f1847ffc752936f3641d95e087f4600a61ba77902d41cf65c2508e338L1-R7) .nuget/Cuemon.Extensions.AspNetCore.Mvc/PackageReleaseNotes.txt [[15]](diffhunk://#diff-d725821a6ec40102da98820f4a1c354b679f716573a320095c58066b3a3c56f6L1-R7) .nuget/Cuemon.Extensions.AspNetCore.Text.Json/PackageReleaseNotes.txt [[16]](diffhunk://#diff-b5a0ec98c42bdef671bed7122950074898eadb956e9e43e21fa6b1f9771f4a2bL1-R7) .nuget/Cuemon.Extensions.AspNetCore.Xml/PackageReleaseNotes.txt [[17]](diffhunk://#diff-014b57b95925e894eda7beee19278c7ff6cd6922b5744ad0fc381f6c2a29ec24L1-R7) .nuget/Cuemon.Extensions.AspNetCore/PackageReleaseNotes.txt [[18]](diffhunk://#diff-c40b251ae8a7daa71d4cd3e7feceb784e2c83dda5bce2c2299c714b71c3f613fL1-R7) .nuget/Cuemon.Extensions.Collections.Generic/PackageReleaseNotes.txt [[19]](diffhunk://#diff-ab0b535dfd0c6ba321e5bfbcab3ab5f8f5943f4c216fdf0f56d128291aa4ccefL1-R7)

Build Environment:

* Updated the NGINX base image version in `.docfx/Dockerfile.docfx` from 1.29.0-alpine to 1.29.1-alpine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated dependencies across .NET 9/8 and .NET Standard targets (incl. Microsoft.Extensions, SQL clients, xUnit tooling) to latest patch versions.
  - Bumped Docker base NGINX image to 1.29.1-alpine.
  - Refreshed test runner Docker image to the latest tag.

- Documentation
  - Added 9.0.9 release notes across packages, noting availability for .NET 9/.NET 8 and updated dependencies.
  - Updated changelog with a 9.0.9 entry indicating a service update focused on dependency refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->